### PR TITLE
no error if already exist

### DIFF
--- a/app-template/Makefile
+++ b/app-template/Makefile
@@ -20,7 +20,7 @@ ios: $(WORKDIR)ios
 
 android: project-android
 	mkdir -p android/platforms/android/res/xml/
-	mkdir $(WORKDIR)android/scripts
+	mkdir -p $(WORKDIR)android/scripts
 	cp -R scripts/* $(WORKDIR)android/scripts
 	cp android/build-extras.gradle  $(WORKDIR)android/platforms/android/build-extras.gradle
 	cp android/project.properties  $(WORKDIR)android/platforms/android/project.properties


### PR DESCRIPTION
grunt android-debug fail when /scripts already exists