### PR TITLE
getCoinAndNetwork has 2nd network param with default livenet

### DIFF
--- a/src/pages/add/create-wallet/create-wallet.html
+++ b/src/pages/add/create-wallet/create-wallet.html
@@ -59,15 +59,17 @@
         <ion-input type="text" formControlName="recoveryPhrase"></ion-input>
       </ion-item>
 
-      <ion-item [ngClass]="{'with-label': createForm.value.testnetEnabled}" *ngIf="checkIfUtxoCoin() && createForm.value.selectedSeed == 'new'">
-        <ion-label>Testnet</ion-label>
+      <ion-item [ngClass]="{'with-label': createForm.value.testnetEnabled}" *ngIf="createForm.value.selectedSeed == 'new'">
+        <ion-label *ngIf="checkIfUtxoCoin()">Testnet</ion-label>
+        <ion-label *ngIf="coin == 'eth'">Kovan Testnet</ion-label>
         <ion-toggle formControlName="testnetEnabled" (ionChange)="setDerivationPath()"></ion-toggle>
       </ion-item>
 
       <label-tip *ngIf="createForm.value.testnetEnabled && createForm.value.selectedSeed == 'new'" type="warn">
-        <span label-tip-title translate>Testnet Wallet</span>
+        <span label-tip-title translate *ngIf="checkIfUtxoCoin()">Testnet Wallet</span>
+        <span label-tip-title translate *ngIf="coin == 'eth'">Kovan Testnet Wallet</span>
         <div label-tip-body translate>
-          The testnet is an alternative Bitcoin block chain, to be used for testing. Testnet coins are separate and distinct from actual bitcoins, and do not have any value. This allows application developers or bitcoin testers to experiment, without having to use real bitcoins.
+          The testnet is an alternative {{ coin.toUpperCase() }} block chain, to be used for testing. Testnet coins are separate and distinct from actual {{ coin.toUpperCase() }}, and do not have any value. This allows application developers or testers to experiment, without having to use real {{ coin.toUpperCase() }}.
         </div>
       </label-tip>
 

--- a/src/pages/includes/multiple-outputs/multiple-outputs.ts
+++ b/src/pages/includes/multiple-outputs/multiple-outputs.ts
@@ -34,7 +34,8 @@ export class MultipleOutputsPage {
       const outputAddr = output.toAddress ? output.toAddress : output.address;
       this.coin = this._tx.coin
         ? this._tx.coin
-        : this.addressProvider.getCoinAndNetwork(outputAddr).coin;
+        : this.addressProvider.getCoinAndNetwork(outputAddr, this._tx.network)
+            .coin;
 
       const addressToShow = this.walletProvider.getAddressView(
         this.coin,

--- a/src/pages/send/multi-send/multi-send.ts
+++ b/src/pages/send/multi-send/multi-send.ts
@@ -264,19 +264,20 @@ export class MultiSendPage extends WalletTabsChild {
   }
 
   private checkCoinAndNetwork(data): boolean {
-    const addrData = this.addressProvider.getCoinAndNetwork(data);
-    const isValid =
-      this.wallet.coin == addrData.coin &&
-      (addrData.network == 'any' || addrData.network == this.wallet.network);
+    let isValid;
+
+    isValid = this.addressProvider.checkCoinAndNetworkFromAddr(
+      this.wallet.coin,
+      this.wallet.network,
+      data
+    );
 
     if (isValid) {
       this.invalidAddress = false;
       return true;
-    } else {network
+    } else {
       this.invalidAddress = true;
-      const network = addrData.network;
-
-      if (this.wallet.coin === 'bch' && this.wallet.network === network) {
+      if (this.wallet.coin === 'bch') {
         const isLegacy = this.checkIfLegacy();
         isLegacy ? this.showLegacyAddrMessage() : this.showErrorMessage();
       } else {

--- a/src/pages/send/send.ts
+++ b/src/pages/send/send.ts
@@ -122,15 +122,19 @@ export class SendPage extends WalletTabsChild {
   }
 
   private checkCoinAndNetwork(data, isPayPro?): boolean {
-    let isValid, addrData;
+    let isValid;
     if (isPayPro) {
-      isValid =
-        data.coin == this.wallet.coin && data.network == this.wallet.network;
+      isValid = this.addressProvider.checkCoinAndNetworkFromPayPro(
+        this.wallet.coin,
+        this.wallet.network,
+        data
+      );
     } else {
-      addrData = this.addressProvider.getCoinAndNetwork(data);
-      isValid =
-        this.wallet.coin == addrData.coin &&
-        (addrData.network == 'any' || addrData.network == this.wallet.network);
+      isValid = this.addressProvider.checkCoinAndNetworkFromAddr(
+        this.wallet.coin,
+        this.wallet.network,
+        data
+      );
     }
 
     if (isValid) {
@@ -138,9 +142,7 @@ export class SendPage extends WalletTabsChild {
       return true;
     } else {
       this.invalidAddress = true;
-      let network = isPayPro ? data.network : addrData.network;
-
-      if (this.wallet.coin === 'bch' && this.wallet.network === network) {
+      if (this.wallet.coin === 'bch') {
         const isLegacy = this.checkIfLegacy();
         isLegacy ? this.showLegacyAddrMessage() : this.showErrorMessage();
       } else {

--- a/src/pages/send/transfer-to/transfer-to.ts
+++ b/src/pages/send/transfer-to/transfer-to.ts
@@ -182,8 +182,7 @@ export class TransferToPage {
   }): boolean {
     return this._wallet
       ? this._wallet.coin === recipient.coin &&
-          (recipient.network == 'any' ||
-            this._wallet.network === recipient.network)
+          this._wallet.network === recipient.network
       : true;
   }
 

--- a/src/providers/address-book/address-book.ts
+++ b/src/providers/address-book/address-book.ts
@@ -77,9 +77,6 @@ export class AddressBookProvider {
         return reject(msg);
       }
 
-      // assumes livenet for `any` addr
-      if (addrData.network == 'any') addrData.network = 'livenet';
-
       this.persistenceProvider
         .getAddressBook(addrData.network)
         .then(ab => {

--- a/src/providers/address/address.spec.ts
+++ b/src/providers/address/address.spec.ts
@@ -9,7 +9,7 @@ describe('AddressProvider', () => {
     addressProvider = testBed.get(AddressProvider);
   });
 
-  fdescribe('getCoinAndNetwork', () => {
+  describe('getCoinAndNetwork', () => {
     const testVectors: any[] = [
       // Bech32
       ['bc1q9225pawdj2dlwsk3dd8phudsap6vjp7fg3nwdl', 'btc', 'livenet'],
@@ -62,13 +62,19 @@ describe('AddressProvider', () => {
         'testnet'
       ],
       ['BCHTEST:qqycye950l689c98l7z5j43n4484ssnp4y3uu4ramr', 'bch', 'testnet'],
-      ['0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'eth', 'any'],
-      ['etherum:0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'eth', 'any'],
       [
         'BCHTEST:qqycye950l689c98l7z5j43n4484ssnp4y3uu4ramr?amount=0.00090000',
         'bch',
         'testnet'
-      ]
+      ],
+      // ETH Address / URI
+      ['0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'eth', 'livenet'],
+      ['etherum:0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'eth', 'livenet']
+    ];
+
+    const ethTestVectors: any[] = [
+      ['0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'eth', 'testnet'],
+      ['etherum:0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'eth', 'testnet']
     ];
 
     testVectors.forEach(v => {
@@ -77,6 +83,346 @@ describe('AddressProvider', () => {
         expect(addrData.coin).toEqual(v[1]);
         expect(addrData.network).toEqual(v[2]);
       });
+    });
+
+    ethTestVectors.forEach(v => {
+      it('address ' + v[0] + ' should be ' + v[1] + ' / ' + v[2], () => {
+        let addrData = addressProvider.getCoinAndNetwork(v[0], 'testnet');
+        expect(addrData.coin).toEqual(v[1]);
+        expect(addrData.network).toEqual(v[2]);
+      });
+    });
+  });
+
+  describe('checkCoinAndNetworkFromAddr', () => {
+    it('should return true if use correct coin and network for BTC livenet native segwit address', () => {
+      let coin = 'btc';
+      let network = 'livenet';
+      let BTCLivenetAddress = 'bc1q9225rawdn2dlwsk3dd8phudsap6vjp7fgwh45q';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCLivenetAddress
+      );
+      expect(result).toEqual(true);
+
+      BTCLivenetAddress = 'bitcoin:bc1q9225rawdn2dlwsk3dd8phudsap6vjp7fgwh45q';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCLivenetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for BTC testnet native segwit address', () => {
+      let coin = 'btc';
+      let network = 'testnet';
+      let BTCLivenetAddress =
+        'tb1q9225pawdn2dlwsk3dd8phudsap6vjp7fhqj5wnrpg457qjq0ycvs6pluck';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCLivenetAddress
+      );
+      expect(result).toEqual(true);
+
+      BTCLivenetAddress =
+        'bitcoin:tb1q9225pawdn2dlwsk3dd8phudsap6vjp7fhqj5wnrpg457qjq0ycvs6pluck';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCLivenetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for BTC livenet address', () => {
+      let coin = 'btc';
+      let network = 'livenet';
+      let BTCLivenetAddress = '15qT4RJTjs7GSTReEmgXr4LbMjTVQ51LZA';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCLivenetAddress
+      );
+      expect(result).toEqual(true);
+
+      BTCLivenetAddress = 'bitcoin:1CVuVALD6Zo7ms24n3iUXv162kvUzsHr69';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCLivenetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for ETH livenet address', () => {
+      let coin = 'eth';
+      let network = 'livenet';
+      let ETHLivenetAddress = '0x32ed5be73f5c395621287f5cbe1da96caf3c5dec';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        ETHLivenetAddress
+      );
+      expect(result).toEqual(true);
+
+      ETHLivenetAddress = 'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        ETHLivenetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for ETH testnet address', () => {
+      let coin = 'eth';
+      let network = 'testnet';
+      let ETHLivenetAddress = '0x32ed5be73f5c395621287f5cbe1da96caf3c5dec';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        ETHLivenetAddress
+      );
+      expect(result).toEqual(true);
+
+      ETHLivenetAddress = 'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        ETHLivenetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for BTC testnet address', () => {
+      let coin = 'btc';
+      let network = 'testnet';
+      let BTCTestnetAddress = 'mscoRRUxbicZdUms3EqDr9jwtCmbbPgfcY';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCTestnetAddress
+      );
+      expect(result).toEqual(true);
+
+      BTCTestnetAddress = 'bitcoin:n3LHh1WTFSpSVKXNFQo4U5eLAqowCadFHY';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BTCTestnetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for BCH livenet address', () => {
+      let coin = 'bch';
+      let network = 'livenet';
+      let BCHLivenetAddress = 'qq9jk8jskjsmgqnzygwjsghp3knautm2dcnc5e4k7n';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BCHLivenetAddress
+      );
+      expect(result).toEqual(true);
+
+      BCHLivenetAddress =
+        'BITCOINCASH:qz8ds306px5n65gffn8u69vvnksfw6huwyjczrvkh3';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BCHLivenetAddress
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return true if use correct coin and network for BCH testnet address', () => {
+      let coin = 'bch';
+      let network = 'testnet';
+      let BCHTestnetAddress = 'qqr99gt5qdk4qyaxxvzeapgjuxkg6x9ueue95fakj7';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BCHTestnetAddress
+      );
+      expect(result).toEqual(true);
+
+      // TODO: we have to update BWS with bitcore-lib-cash version 0.18.1 to get correct values for BCHTEST prefix
+      /* BCHTestnetAddress = 'BCHTEST:qqycye950l689c98l7z5j43n4484ssnp4y3uu4ramr';
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        BCHTestnetAddress
+      );
+      expect(result).toEqual(true); */
+    });
+
+    it('should return false if we send an invalid address, coin or network', () => {
+      let coin = 'btc';
+      let network = 'livenet';
+      let address = 'invalidAddress';
+      let result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'btc';
+      network = 'testnet';
+      address = '1CVuVALD6Zo7ms24n3iUXv162kvUzsHr69'; // BTC livenet
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'bch';
+      network = 'livenet';
+      address = 'bitcoin:1CVuVALD6Zo7ms24n3iUXv162kvUzsHr69'; // BTC livenet
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'bch';
+      network = 'testnet';
+      address = 'bitcoincash:qz8ds306px5n65gffn8u69vvnksfw6huwyjczrvkh3'; // BCH livenet
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'btc';
+      network = 'livenet';
+      address = 'BITCOINCASH:qz8ds306px5n65gffn8u69vvnksfw6huwyjczrvkh3'; // BCH livenet
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'btc';
+      network = 'testnet';
+      address = 'bc1q9225rawdn2dlwsk3dd8phudsap6vjp7fgwh45q'; // BTC livenet native segwit
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'eth';
+      network = 'livenet';
+      address = '0xinvalidAddress'; // ETH livenet
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+
+      coin = 'eth';
+      network = 'testnet';
+      address = 'ethereum:0xinvalidAddress'; // ETH URI testnet
+      result = addressProvider.checkCoinAndNetworkFromAddr(
+        coin,
+        network,
+        address
+      );
+      expect(result).toBeFalsy();
+    });
+  });
+
+  describe('checkCoinAndNetworkFromPayPro', () => {
+    it('should return true if use correct coin and network for paypro details', () => {
+      let coin = 'btc';
+      let network = 'livenet';
+      let payproDetails = {
+        coin: 'btc',
+        network: 'livenet'
+      };
+      let result = addressProvider.checkCoinAndNetworkFromPayPro(
+        coin,
+        network,
+        payproDetails
+      );
+      expect(result).toEqual(true);
+
+      coin = 'bch';
+      network = 'livenet';
+      payproDetails = {
+        coin: 'bch',
+        network: 'livenet'
+      };
+      result = addressProvider.checkCoinAndNetworkFromPayPro(
+        coin,
+        network,
+        payproDetails
+      );
+      expect(result).toEqual(true);
+
+      coin = 'eth';
+      network = 'livenet';
+      payproDetails = {
+        coin: 'eth',
+        network: 'livenet'
+      };
+      result = addressProvider.checkCoinAndNetworkFromPayPro(
+        coin,
+        network,
+        payproDetails
+      );
+      expect(result).toEqual(true);
+    });
+
+    it('should return false if use incorrect coin or network for paypro details', () => {
+      let coin = 'btc';
+      let network = 'testnet';
+      let payproDetails = {
+        coin: 'btc',
+        network: 'livenet'
+      };
+      let result = addressProvider.checkCoinAndNetworkFromPayPro(
+        coin,
+        network,
+        payproDetails
+      );
+      expect(result).toEqual(false);
+
+      coin = 'bch';
+      network = 'livenet';
+      payproDetails = {
+        coin: 'btc',
+        network: 'livenet'
+      };
+      result = addressProvider.checkCoinAndNetworkFromPayPro(
+        coin,
+        network,
+        payproDetails
+      );
+      expect(result).toEqual(false);
+
+      coin = 'eth';
+      network = 'livenet';
+      payproDetails = {
+        coin: 'eth',
+        network: 'testnet'
+      };
+      result = addressProvider.checkCoinAndNetworkFromPayPro(
+        coin,
+        network,
+        payproDetails
+      );
+      expect(result).toEqual(false);
     });
   });
 
@@ -122,6 +468,21 @@ describe('AddressProvider', () => {
         'BCHTEST:qz8ds306px5n65gffn8u69vvnksfw6huwyjczrvkh3?amount=0.00090000'; // BCH testnet uri
       result = addressProvider.extractAddress(address);
       expect(result).toEqual('qz8ds306px5n65gffn8u69vvnksfw6huwyjczrvkh3');
+    });
+
+    it('should return the correct extracted address for ETH', () => {
+      let address = '0x32ed5be73f5c395621287f5cbe1da96caf3c5dec'; // ETH livenet
+      let result = addressProvider.extractAddress(address);
+      expect(result).toEqual('0x32ed5be73f5c395621287f5cbe1da96caf3c5dec');
+
+      address = 'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec'; // ETH livenet with prefix
+      result = addressProvider.extractAddress(address);
+      expect(result).toEqual('0x32ed5be73f5c395621287f5cbe1da96caf3c5dec');
+
+      address =
+        'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec?value=1234567890'; // ETH livenet uri
+      result = addressProvider.extractAddress(address);
+      expect(result).toEqual('0x32ed5be73f5c395621287f5cbe1da96caf3c5dec');
     });
   });
 
@@ -184,6 +545,21 @@ describe('AddressProvider', () => {
       expect(result).toEqual(true);
     });
 
+    it('should return true for addresses of ETH livenet', () => {
+      let address = '0x32ed5be73f5c395621287f5cbe1da96caf3c5dec'; // ETH livenet
+      let result = addressProvider.isValid(address);
+      expect(result).toEqual(true);
+
+      address = 'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec'; // ETH livenet with prefix
+      result = addressProvider.isValid(address);
+      expect(result).toEqual(true);
+
+      address =
+        'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec?value=1234567890'; // ETH livenet uri
+      result = addressProvider.isValid(address);
+      expect(result).toEqual(true);
+    });
+
     // TODO: we have to update BWS with bitcore-lib-cash version 0.18.1 to get correct values for BCHTEST prefix
     /* it('should return true for addresses of BCH testnet', () => {
       address = 'BCHTEST:qz8ds306px5n65gffn8u69vvnksfw6huwyjczrvkh3'; // BCH testnet with prefix
@@ -206,6 +582,11 @@ describe('AddressProvider', () => {
       expect(result).toEqual(false);
 
       address = 'bchtest:1CVuVALD6Zo7ms24n3iUXv162kvUzsHr69?amount=invalid';
+      result = addressProvider.isValid(address);
+      expect(result).toEqual(false);
+
+      address =
+        'ethereum:0x32ed5be73f5c395621287f5cbe1da96caf3c5dec?value=invalid';
       result = addressProvider.isValid(address);
       expect(result).toEqual(false);
     });

--- a/src/providers/address/address.ts
+++ b/src/providers/address/address.ts
@@ -20,9 +20,8 @@ export class AddressProvider {
     return extractedAddress;
   }
 
-  public getCoinAndNetwork(str: string): any {
+  public getCoinAndNetwork(str: string, network: string = 'livenet'): any {
     const address = this.extractAddress(str);
-    let network = null;
     try {
       network = this.bitcore.Address(address).network.name;
       return { coin: 'btc', network };
@@ -34,11 +33,11 @@ export class AddressProvider {
         try {
           const isValidEthAddress = this.core.Validation.validateAddress(
             'ETH',
-            'livenet',
+            network,
             address
           );
           if (isValidEthAddress) {
-            return { coin: 'eth', network: 'any' };
+            return { coin: 'eth', network };
           } else {
             return null;
           }
@@ -48,8 +47,33 @@ export class AddressProvider {
       }
     }
   }
-  //  public checkCoinAndNetworkFromAddr(
-  //  public checkCoinAndNetworkFromPayPro(
+
+  public checkCoinAndNetworkFromPayPro(
+    coin: string,
+    network: string,
+    payProDetails
+  ): boolean {
+    return payProDetails.coin == coin && payProDetails.network == network
+      ? true
+      : false;
+  }
+
+  public checkCoinAndNetworkFromAddr(
+    coin: string,
+    network: string,
+    str: string
+  ): boolean {
+    if (this.isValid(str)) {
+      const address = this.extractAddress(str);
+      return this.core.Validation.validateAddress(
+        coin.toUpperCase(),
+        network,
+        address
+      );
+    } else {
+      return false;
+    }
+  }
 
   public isValid(str: string): boolean {
     // Check if the input is a valid uri or address


### PR DESCRIPTION
```
getCoinAndNetwork('0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C', 'testnet')
```
Returns:
`{ coin: 'eth', network: 'testnet' }`

```
getCoinAndNetwork('0x1CD7b5A3294c8714DB5c48e56DD11a6d7EAeaB4C')
```

Returns:
`{ coin: 'eth', network: 'livenet' }`